### PR TITLE
updated sonarcloud workflow to use compilation database from build wr…

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -97,5 +97,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN  }} # Put the name of your token here
         run: |
           sonar-scanner \
-          --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+          --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" \
           -Dsonar.coverageReportPaths=artifact/sonarqube-generic-coverage.xml


### PR DESCRIPTION
Addresses Issue https://github.com/mccaffers/backtesting-engine-cpp/issues/1 - Property 'sonar.cfamily.build-wrapper-output' is deprecated; build-wrapper now generates a compilation database