### PR TITLE
Rethrow parse_error in JsonParser::parseConfigurationFromBase64

### DIFF
--- a/source/utilities/jsonParser.cpp
+++ b/source/utilities/jsonParser.cpp
@@ -23,8 +23,9 @@ trading_definitions::Configuration JsonParser::parseConfigurationFromBase64(cons
     }
     catch (json::parse_error& ex) {
         std::cerr << "parse error at byte " << ex.byte << std::endl;
+        throw;
     }
-    
+
     auto config = j.get<trading_definitions::Configuration>();
     std::cout << config.RUN_ID << std::endl;
 


### PR DESCRIPTION
The catch block logged the byte offset and then fell through , leaving `j`                                                                                                                                 
  as a null JSON value