### PR TITLE
Throw on unknown symbol in Trade constructor

### DIFF
--- a/include/models/trade.hpp
+++ b/include/models/trade.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <chrono>
+#include <stdexcept>
 #include "symbolScale.hpp"
 #include <boost/decimal.hpp>
 
@@ -59,6 +60,9 @@ struct Trade {
           stopDistancePips(0),
           limitDistancePips(0),
           pnl(0) {
+        if (scalingFactor == symbol_scale::kUnknown) {
+            throw std::invalid_argument("Trade: unknown symbol '" + std::string(tradeSymbol) + "' has no pip scale");
+        }
     }
 
 };


### PR DESCRIPTION
symbol_scale::get returns kUnknown (0) for symbols missing from kTable

That value flowed straight into Trade::scalingFactor and silently zeroed out PnL on close (pnl = diff * scalingFactor * size), producing a clean-looking backtest with corrupted results