### PR TITLE
Fix high-severity bugs

### DIFF
--- a/source/databaseConnection.cpp
+++ b/source/databaseConnection.cpp
@@ -19,10 +19,20 @@ static std::chrono::system_clock::time_point fastParseTimestamp(const char* ts) 
     if (parsedFields != 6 && parsedFields != 7) {
         throw std::runtime_error("Invalid timestamp format");
     }
+    if (month < 1 || month > 12 ||
+        day   < 1 || day   > 31 ||
+        hour  < 0 || hour  > 23 ||
+        min   < 0 || min   > 59 ||
+        sec   < 0 || sec   > 60 ||
+        usec  < 0 || usec  > 999999) {
+        throw std::runtime_error("Invalid timestamp field range");
+    }
 
-    // Cache timegm per date — tick data is time-ordered so date changes rarely
-    static char cachedDate[11] = {};
-    static time_t cachedEpoch = 0;
+    // Cache timegm per date — tick data is time-ordered so date changes rarely.
+    // thread_local: every thread has its own cache, eliminating data races if
+    // streamQuery is ever invoked concurrently.
+    thread_local char cachedDate[11] = {};
+    thread_local time_t cachedEpoch = 0;
     if (std::memcmp(ts, cachedDate, 10) != 0) {
         std::memcpy(cachedDate, ts, 10);
         std::tm tm = {};

--- a/source/utilities/base64.cpp
+++ b/source/utilities/base64.cpp
@@ -7,6 +7,8 @@
 #include <iomanip>  // Add this header for std::get_time
 #include <sstream>
 #include <chrono>
+#include <cctype>
+#include <stdexcept>
 #include "base64.hpp"
 
 static const char* const B64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -62,6 +64,31 @@ const std::string Base64::b64encode(const void* data, const size_t &len)
 const std::string Base64::b64decode(const void* data, const size_t &len)
 {
     if (len == 0) return "";
+
+    // Validate up front so the decode loop can rely on a well-formed input.
+    // Without this:
+    //   - len == 1 reads p[len - 2] = p[-1] (out-of-bounds).
+    //   - len == 2 or 3 produces a result string smaller than the padding
+    //     branch writes into.
+    //   - any non-base64 byte silently maps via B64index to 0 ('A'), so the
+    //     decoder returns garbage instead of failing.
+    if (len % 4 != 0) {
+        throw std::invalid_argument("Base64::b64decode: input length must be a multiple of 4");
+    }
+    {
+        const unsigned char* q = static_cast<const unsigned char*>(data);
+        for (size_t i = 0; i < len; ++i) {
+            const unsigned char c = q[i];
+            const bool valid =
+                (c >= 'A' && c <= 'Z') ||
+                (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                c == '+' || c == '/' || c == '=';
+            if (!valid) {
+                throw std::invalid_argument("Base64::b64decode: invalid character in input");
+            }
+        }
+    }
 
     unsigned char *p = (unsigned char*) data;
     size_t j = 0,
@@ -119,16 +146,30 @@ std::chrono::system_clock::time_point Utilities::parseTimestamp(const std::strin
     std::tm tm = {};
     std::istringstream ss(ts);
     ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-    
-    auto timePoint = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-    
-    // Parse milliseconds if present
-    if (ss.peek() == '.') {
-        ss.ignore(); // Skip the dot
-        int milliseconds;
-        ss >> milliseconds;
-        timePoint += std::chrono::milliseconds(milliseconds / 1000); // Convert microseconds to milliseconds
+    if (ss.fail()) {
+        throw std::runtime_error("Utilities::parseTimestamp: invalid timestamp format");
     }
-    
+
+    // Treat the parsed time as UTC (timegm), matching fastParseTimestamp in
+    // databaseConnection.cpp. std::mktime would interpret it as local time
+    // and silently shift everything by the host TZ offset.
+    auto timePoint = std::chrono::system_clock::from_time_t(timegm(&tm));
+
+    // Parse fractional seconds if present. The DB may emit any number of
+    // digits (e.g. ".1", ".123", ".123456"); pad/truncate to 6 digits so
+    // the value is always interpreted as microseconds.
+    if (ss.peek() == '.') {
+        ss.ignore();
+        std::string frac;
+        while (std::isdigit(static_cast<unsigned char>(ss.peek()))) {
+            frac.push_back(static_cast<char>(ss.get()));
+        }
+        if (!frac.empty()) {
+            if (frac.size() < 6) frac.append(6 - frac.size(), '0');
+            else if (frac.size() > 6) frac.resize(6);
+            timePoint += std::chrono::microseconds(std::stoi(frac));
+        }
+    }
+
     return timePoint;
 }


### PR DESCRIPTION
* fastParseTimestamp: switch the date cache from `static` to `thread_local` to avoid a data race if streamQuery is ever called concurrently
* Utilities::parseTimestamp: replace `std::mktime` with `timegm` so the parsed time is interpreted as UTC , matching fastParseTimestamp
* Base64::b64decode: validate the input length and alphabet up front (I don't like the my checks with a lot of 'if' checks, but it is fast)